### PR TITLE
Feature/switch from mock to api

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ configuration.
     "publicPath": "/dist/",
     "APIPrefix": "http://127.0.0.1:7300/api",
     "uploadAPI": "Your own avatar uploading API uri",
-    "storageNamespace": "cookies & localStorage namespace"
+    "storageNamespace": "cookies & localStorage namespace",
+    "canSwitchAddress": false // turn on the feature to switch mock to API address
   }
 }
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,8 @@ $ cd easy-mock && npm install
     "publicPath": "/dist/",
     "APIPrefix": "http://127.0.0.1:7300/api",
     "uploadAPI": "你的上传接口地址，头像上传需要。",
-    "storageNamespace": "cookies & localStorage 的命名空间。"
+    "storageNamespace": "cookies & localStorage 的命名空间。",
+    "canSwitchAddress": false // 开启此功能允许你填写 API 测试地址并进行切换
   }
 }
 ```

--- a/config/default.json
+++ b/config/default.json
@@ -68,6 +68,7 @@
     "timeout": 25000,
     "publicPath": "/dist/",
     "mockPrefix": "/mock/",
-    "APIPrefix": "http://127.0.0.1:7300/api"
+    "APIPrefix": "http://127.0.0.1:7300/api",
+    "canSwitchAddress": false
   }
 }

--- a/controllers/mock.js
+++ b/controllers/mock.js
@@ -179,6 +179,7 @@ exports.update = function * () {
   const id = this.checkBody('id').notEmpty().value
   const mode = this.checkBody('mode').value
   const description = this.checkBody('description').value
+  const isAuthentic = this.checkBody('is_authentic').value
   const url = this.checkBody('url').empty()
     .match(/^\/.*$/i, 'URL 必须以 / 开头').value
   const method = this.checkBody('method').empty().toLow().in([
@@ -212,6 +213,7 @@ exports.update = function * () {
   mock.mode = mode || mock.mode
   mock.method = method || mock.method
   mock.description = description || mock.description
+  mock.is_authentic = isAuthentic
 
   // 更新属性后查重
   const existMock = yield mockProxy.findOne({

--- a/controllers/mock.js
+++ b/controllers/mock.js
@@ -276,6 +276,7 @@ exports.delete = function * () {
 exports.getMock = function * () {
   const query = this.query || {}
   const body = this.request.body || {}
+  const header = this.request.header || {}
   const method = this.method.toLowerCase()
   const urlArr = _.filter(this.path.split('/')) // filter empty
   const userName = urlArr[1]
@@ -351,6 +352,12 @@ exports.getMock = function * () {
         url: url.origin + pathname,
         params: queryString,
         data: body,
+        headers: {
+          'content-type': header['content-type'] || 'application/json',
+          'x-authorization': header['x-authorization'] || '',
+          'client-key': header['client-key'] || '',
+          'accept': header['accept'] || 'application/json'
+        },
         timeout: 10000
       }).then(res => res.data)
     } catch (error) {

--- a/controllers/mock.js
+++ b/controllers/mock.js
@@ -339,7 +339,7 @@ exports.getMock = function * () {
     return options.template.call(options.context.currentContext, options)
   }.bind(this)
 
-  if (project.address && mock.is_authentic) {
+  if (config.fe && config.fe.canSwitchAddress && project.address && mock.is_authentic) {
     const mode = project.address + mock.url
     const proxy = mode.split('?')
     const url = new URL(proxy[0])

--- a/controllers/project.js
+++ b/controllers/project.js
@@ -122,6 +122,9 @@ exports.create = function * () {
   const swaggerUrl = this.checkBody('swagger_url').empty().isUrl(null, {
     allow_underscores: true
   }).value
+  const address = this.checkBody('address').empty().isUrl(null, {
+    allow_underscores: true
+  }).value
   const memberIds = this.checkBody('members').empty()
     .type('array').value
   const url = this.checkBody('url').notEmpty()
@@ -134,6 +137,7 @@ exports.create = function * () {
     name,
     url,
     swagger_url: swaggerUrl,
+    address: address,
     description: description || name
   }
 
@@ -248,6 +252,9 @@ exports.update = function * () {
   const swaggerUrl = this.checkBody('swagger_url').empty().isUrl(null, {
     allow_underscores: true
   }).value
+  const address = this.checkBody('address').empty().isUrl(null, {
+    allow_underscores: true
+  }).value
   const memberIds = this.checkBody('members').empty()
     .type('array').value
   const url = this.checkBody('url').empty()
@@ -296,6 +303,7 @@ exports.update = function * () {
   project.name = name || project.name
   project.members = memberIds || project.members
   project.swagger_url = swaggerUrl || project.swagger_url
+  project.address = address || project.address
   project.description = description || project.description
 
   const existQuery = {

--- a/models/fields_table.js
+++ b/models/fields_table.js
@@ -4,7 +4,7 @@ module.exports = {
   group: ['_id', 'name'],
   mock: ['_id', 'url', 'method', 'description', 'mode', 'parameters', 'response_model', 'is_authentic'],
   user: ['_id', 'name', 'nick_name', 'head_img', 'token'],
-  project: ['_id', 'name', 'url', 'description', 'swagger_url',
+  project: ['_id', 'name', 'url', 'description', 'swagger_url', 'address',
     'members', 'extend', 'group'],
   projectExtend: ['_id', 'is_workbench']
 }

--- a/models/fields_table.js
+++ b/models/fields_table.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   group: ['_id', 'name'],
-  mock: ['_id', 'url', 'method', 'description', 'mode', 'parameters', 'response_model'],
+  mock: ['_id', 'url', 'method', 'description', 'mode', 'parameters', 'response_model', 'is_authentic'],
   user: ['_id', 'name', 'nick_name', 'head_img', 'token'],
   project: ['_id', 'name', 'url', 'description', 'swagger_url',
     'members', 'extend', 'group'],

--- a/models/mock.js
+++ b/models/mock.js
@@ -15,6 +15,7 @@ const schema = new Schema({
   method: String,
   parameters: String,
   response_model: String,
+  is_authentic: Boolean,
   create_at: {
     type: Date,
     default: Date.now

--- a/models/project.js
+++ b/models/project.js
@@ -23,6 +23,10 @@ const schema = new Schema({
     type: String,
     default: ''
   },
+  address: {
+    type: String,
+    default: ''
+  },
   members: [{
     type: Schema.Types.ObjectId,
     ref: 'User',

--- a/proxy/mock.js
+++ b/proxy/mock.js
@@ -32,7 +32,8 @@ exports.updateById = function (mock) {
       method: mock.method,
       parameters: mock.parameters,
       description: mock.description,
-      response_model: mock.response_model
+      response_model: mock.response_model,
+      is_authentic: mock.is_authentic
     }
   })
 }

--- a/proxy/project.js
+++ b/proxy/project.js
@@ -70,7 +70,8 @@ exports.updateById = function (project) {
       name: project.name,
       members: project.members,
       description: project.description,
-      swagger_url: project.swagger_url
+      swagger_url: project.swagger_url,
+      address: project.address
     }
   })
 }

--- a/views/locale/en.js
+++ b/views/locale/en.js
@@ -95,6 +95,7 @@ export default {
         url: 'Base URL | Make it shot and expressive, e.g.：/nba',
         description: 'Description | Will be project name if null',
         swagger: 'Swagger Docs API | Optional | If backend provides Swagger Doc (without authentication error), Easy Mock will create Mock based on Swagger API address you provide.',
+        address: 'API Address | Optional | If backend provides API address, Easy Mock will provide a switcher to take over switching from mock to API.',
         member: ['Ask people join for collaboration', 'Optional | Lose effectiveness under team project', 'Support fuzzy search, user nickname, username'],
         confirm: 'Please type in the name of the project to confirm. | Project name | This action <strong>CANNOT<strong> be undone. This will permanently delete project:',
         button: {

--- a/views/locale/en.js
+++ b/views/locale/en.js
@@ -164,7 +164,7 @@ export default {
         { category: 'Edit（for not editmode）', list: ['Close', 'Formating', 'Preview'] }
       ],
       columns: ['Description', 'Action'],
-      action: ['Preview Mock', 'Edit Mock', 'Copy Mock Address', 'Copy', 'Delete'],
+      action: ['Preview Mock', 'Edit Mock', 'Copy Mock Address', 'Copy', 'Delete', 'Switch Api Address'],
       copySuccess: 'Project address is in clipboard',
       syncSwagger: {
         action: 'Sync Swagger',

--- a/views/locale/zh-CN.js
+++ b/views/locale/zh-CN.js
@@ -95,6 +95,7 @@ export default {
         url: '项目基础 URL | 尽量简短表意。例：/nba',
         description: '项目描述 | 不填默认为项目名',
         swagger: 'Swagger Docs API | 可选 | 如果后台有提供 Swagger 文档（并且没有验证授权的问题）, 于是我们可以在此处填写 Swagger 的接口地址, Easy Mock 会自动基于此接口创建 Mock 接口.',
+        address: 'API 服务地址 | 可选 | 我们可以填写 api 的测试环境的地址，Easy Mock 可以接管切换 mock 与测试环境的操作，来实现测试环境的对接和集成.',
         member: ['邀请成员 协同编辑', '可选 | 团队项目下，该配置不生效', '用户昵称、用户名，支持模糊匹配'],
         confirm: '请输入项目名称以进行确认 | 项目名确认 | 出于某些原因，删除也许会失败。但如果你执意删除，必须知道此操作无法撤消，这将永久删除',
         button: {

--- a/views/locale/zh-CN.js
+++ b/views/locale/zh-CN.js
@@ -164,7 +164,7 @@ export default {
         { category: '编辑界面（非编辑状态有效）', list: ['关闭', '格式化', '预览（只在更新时生效）'] }
       ],
       columns: ['描述', '操作'],
-      action: ['预览接口', '编辑接口', '复制接口地址', '克隆', '删除'],
+      action: ['预览接口', '编辑接口', '复制接口地址', '克隆', '删除', '切换数据源'],
       copySuccess: '接口地址已复制到剪贴板',
       syncSwagger: {
         action: '同步 Swagger',

--- a/views/pages/new/project.vue
+++ b/views/pages/new/project.vue
@@ -53,14 +53,14 @@
             {{$tc('p.new.form.swagger', 2)}} <router-link to="/docs#swagger"><Icon type="help-circled"></Icon></router-link>
             </p>
           </Form-item>
-          <Form-item label="项目地址">
+          <Form-item :label="$tc('p.new.form.address', 0)">
             <template slot="label">
-              API 服务地址
-              <span>(可选)</span>
+              {{$tc('p.new.form.address', 0)}}
+              <span>({{$tc('p.new.form.address', 1)}})</span>
             </template>
             <i-input v-model="form.projectAddress" placeholder="http://example.com"></i-input>
             <p class="em-new__form-description">
-              我们可以在此处填写项目地址, Easy Mock 可以提供 mock 数据和真实数据之间的切换, API 测试完成即可无缝投入使用.
+              {{$tc('p.new.form.address', 2)}}
             </p>
           </Form-item>
           <Form-item :label="$t('p.new.form.member[0]')" class="em-new__form-hr">

--- a/views/pages/new/project.vue
+++ b/views/pages/new/project.vue
@@ -53,6 +53,16 @@
             {{$tc('p.new.form.swagger', 2)}} <router-link to="/docs#swagger"><Icon type="help-circled"></Icon></router-link>
             </p>
           </Form-item>
+          <Form-item label="项目地址">
+            <template slot="label">
+              API 服务地址
+              <span>(可选)</span>
+            </template>
+            <i-input v-model="form.projectAddress" placeholder="http://example.com"></i-input>
+            <p class="em-new__form-description">
+              我们可以在此处填写项目地址, Easy Mock 可以提供 mock 数据和真实数据之间的切换, API 测试完成即可无缝投入使用.
+            </p>
+          </Form-item>
           <Form-item :label="$t('p.new.form.member[0]')" class="em-new__form-hr">
             <template slot="label">
               {{$t('p.new.form.member[0]')}}
@@ -115,6 +125,7 @@ export default {
         projectUrl: '',
         projectDesc: '',
         projectSwagger: '',
+        projectAddress: '',
         projectMembers: []
       }
     }
@@ -137,6 +148,7 @@ export default {
       this.form.projectName = proj.name
       this.form.projectDesc = proj.description
       this.form.projectSwagger = proj.swagger_url
+      this.form.projectAddress = proj.address
       this.projectUrl = proj.url.slice(1) // remove /
       this.$nextTick(() => {
         this.remoteLoading = false
@@ -194,6 +206,7 @@ export default {
         name: this.form.projectName,
         group: this.form.groupId,
         swagger_url: this.form.projectSwagger,
+        address: this.form.projectAddress,
         description: this.form.projectDesc,
         url: this.convertUrl(this.projectUrl),
         members: this.isGroup ? [] : this.form.projectMembers

--- a/views/pages/new/project.vue
+++ b/views/pages/new/project.vue
@@ -53,7 +53,7 @@
             {{$tc('p.new.form.swagger', 2)}} <router-link to="/docs#swagger"><Icon type="help-circled"></Icon></router-link>
             </p>
           </Form-item>
-          <Form-item :label="$tc('p.new.form.address', 0)">
+          <Form-item v-if="canSwitchAddress" :label="$tc('p.new.form.address', 0)">
             <template slot="label">
               {{$tc('p.new.form.address', 0)}}
               <span>({{$tc('p.new.form.address', 1)}})</span>
@@ -108,6 +108,7 @@
 
 <script>
 import * as api from '../../api'
+import config from 'config'
 
 export default {
   name: 'newProject',
@@ -172,6 +173,9 @@ export default {
     },
     isEdit () {
       return !!this.projectData
+    },
+    canSwitchAddress () {
+      return config.canSwitchAddress
     },
     isGroup () {
       if (this.projectData) {

--- a/views/pages/project-detail/index.vue
+++ b/views/pages/project-detail/index.vue
@@ -183,13 +183,15 @@ export default {
           align: 'center',
           render: (h, params) => {
             const switchAddressIcon = params.row.is_authentic ? 'toggle-filled' : 'toggle'
+            let switchAddressButton = <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>
+            switchAddressButton = this.project.address ? switchAddressButton: null
             return (
               <div>
                 <Button-group>
                   <i-button size="small" title={this.$t('p.detail.action[0]')} onClick={this.preview.bind(this, params.row)}><icon type="eye"></icon></i-button>
                   <i-button size="small" title={this.$t('p.detail.action[1]')} onClick={this.openEditor.bind(this, params.row)}><icon type="edit"></icon></i-button>
                   <i-button size="small" title={this.$t('p.detail.action[2]')} class="copy-url" onClick={this.clip.bind(this, params.row.url)}><icon type="link"></icon></i-button>
-                  <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>
+                  {switchAddressButton}
                 </Button-group>
                 <dropdown>
                   <i-button size="small"><icon type="more"></icon></i-button>
@@ -309,7 +311,11 @@ export default {
         }
       }).then((res) => {
         if (res.data.success) {
-          this.$Message.success('更新成功')
+          if (isAuthentic) {
+            this.$Message.success('已使用mock')
+          } else {
+            this.$Message.success('已使用API')
+          }
           this.$store.commit('mock/SET_REQUEST_PARAMS', { pageIndex: 1 })
           this.$store.dispatch('mock/FETCH', this.$route)
         }

--- a/views/pages/project-detail/index.vue
+++ b/views/pages/project-detail/index.vue
@@ -179,15 +179,17 @@ export default {
         {
           title: this.$t('p.detail.columns[1]'),
           key: 'action',
-          width: 160,
+          width: 180,
           align: 'center',
           render: (h, params) => {
+            const switchAddressIcon = params.row.is_authentic ? 'toggle-filled' : 'toggle'
             return (
               <div>
                 <Button-group>
                   <i-button size="small" title={this.$t('p.detail.action[0]')} onClick={this.preview.bind(this, params.row)}><icon type="eye"></icon></i-button>
                   <i-button size="small" title={this.$t('p.detail.action[1]')} onClick={this.openEditor.bind(this, params.row)}><icon type="edit"></icon></i-button>
                   <i-button size="small" title={this.$t('p.detail.action[2]')} class="copy-url" onClick={this.clip.bind(this, params.row.url)}><icon type="link"></icon></i-button>
+                  <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>
                 </Button-group>
                 <dropdown>
                   <i-button size="small"><icon type="more"></icon></i-button>
@@ -297,6 +299,22 @@ export default {
         }
       })
     },
+    switchAuthentic (mock) {
+      const isAuthentic = mock.is_authentic
+      api.mock.update({
+        data: {
+          ...mock,
+          id: mock._id,
+          is_authentic: !isAuthentic
+        }
+      }).then((res) => {
+        if (res.data.success) {
+          this.$Message.success('更新成功')
+          this.$store.commit('mock/SET_REQUEST_PARAMS', { pageIndex: 1 })
+          this.$store.dispatch('mock/FETCH', this.$route)
+        }
+      })
+    },
     remove (mockId) {
       const ids = this.selection.length
         ? this.selection.map(item => item._id)
@@ -321,6 +339,7 @@ export default {
       this.$store.dispatch('project/WORKBENCH', this.project.extend)
     },
     clone (mock) {
+      console.log('clone: mock: ', this.$route, mock, `${mock.url}_copy_${new Date().getTime()}`)
       this.$store.dispatch('mock/CREATE', {
         route: this.$route,
         ...mock,

--- a/views/pages/project-detail/index.vue
+++ b/views/pages/project-detail/index.vue
@@ -184,7 +184,7 @@ export default {
           render: (h, params) => {
             const switchAddressIcon = params.row.is_authentic ? 'toggle-filled' : 'toggle'
             let switchAddressButton = <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>
-            switchAddressButton = this.project.address ? switchAddressButton: null
+            switchAddressButton = this.project.address ? switchAddressButton : null
             return (
               <div>
                 <Button-group>
@@ -345,7 +345,6 @@ export default {
       this.$store.dispatch('project/WORKBENCH', this.project.extend)
     },
     clone (mock) {
-      console.log('clone: mock: ', this.$route, mock, `${mock.url}_copy_${new Date().getTime()}`)
       this.$store.dispatch('mock/CREATE', {
         route: this.$route,
         ...mock,

--- a/views/pages/project-detail/index.vue
+++ b/views/pages/project-detail/index.vue
@@ -181,20 +181,9 @@ export default {
           key: 'action',
           width: 180,
           align: 'center',
-          filters: [
-            { label: 'api', value: 'api' },
-            { label: 'mock', value: 'mock' }
-          ],
-          filterMethod (value, row) {
-            const isAuthentic = row.is_authentic
-            if (value === 'api') {
-              return isAuthentic
-            }
-            return !isAuthentic
-          },
           render: (h, params) => {
             let switchAddressButton = null
-            if (this.project.address) {
+            if (config.canSwitchAddress && this.project.address) {
               const switchAddressIcon = params.row.is_authentic ? 'toggle-filled' : 'toggle'
               switchAddressButton = (
                 <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>

--- a/views/pages/project-detail/index.vue
+++ b/views/pages/project-detail/index.vue
@@ -181,6 +181,17 @@ export default {
           key: 'action',
           width: 180,
           align: 'center',
+          filters: [
+            { label: 'api', value: 'api' },
+            { label: 'mock', value: 'mock' }
+          ],
+          filterMethod (value, row) {
+            const isAuthentic = row.is_authentic
+            if (value === 'api') {
+              return isAuthentic
+            }
+            return !isAuthentic
+          },
           render: (h, params) => {
             const switchAddressIcon = params.row.is_authentic ? 'toggle-filled' : 'toggle'
             let switchAddressButton = <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>

--- a/views/pages/project-detail/index.vue
+++ b/views/pages/project-detail/index.vue
@@ -193,9 +193,13 @@ export default {
             return !isAuthentic
           },
           render: (h, params) => {
-            const switchAddressIcon = params.row.is_authentic ? 'toggle-filled' : 'toggle'
-            let switchAddressButton = <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>
-            switchAddressButton = this.project.address ? switchAddressButton : null
+            let switchAddressButton = null
+            if (this.project.address) {
+              const switchAddressIcon = params.row.is_authentic ? 'toggle-filled' : 'toggle'
+              switchAddressButton = (
+                <i-button size="small" title={this.$t('p.detail.action[5]')} class="switch-address" onClick={this.switchAuthentic.bind(this, params.row)}><icon type={switchAddressIcon}></icon></i-button>
+              )
+            }
             return (
               <div>
                 <Button-group>


### PR DESCRIPTION
## 这个 PR 中做了哪方面的改变?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] 其它, 请描述:

~~我们可以填写项目地址, Easy Mock 可以提供 mock 数据和真实数据之间的切换, API 测试完成即可无缝投入使用.~~

我们可以填写 api 的测试环境的地址，Easy Mock 可以接管切换 mock 与测试环境的操作，来实现测试环境的对接和集成。

## 这个 PR 是否有突破性改变:

- [x] 是
- [ ] 否

## 对现在的应用程序的影响以及迁移方案或兼容方案：

project 模型增加了 address: String 字段，这是一个可选项。mock 模型增加了 is_authentic: Boolean 字段，这是一个可选项，默认为 false。

这两个字段的增加对于现有的逻辑不造成影响。也不需要迁移，用户在使用的过程中配置即可。

当项目的 API 服务地址配置后，在操作界面会增加一个 toggle，如果没有配置，则 toggle 不会出现。

## 这个 PR 应该满足以下条件:

- [x] 提交到 dev 分支，而不是 master 分支
- [x] 遵循 Standard [ESLint](http://standardjs.com)
- [x] 提交前已完成 rebase，确保 commit 记录的整洁
- [x] 解决具体问题时，应该在 PR 的标题中体现出来。（例如：fix #xxx: 描述，xxx 指具体 issue 的编号）
- [x] 通过所有测试用例

## 其他

今天上线之后，发现这个 feature 还有一些 bug:
- [x] 转发时需要同时转发 header 中的内容（已修复）
- [x] 修改一些文案，强调此功能应该只用于测试环境（已修复）