### PR TITLE
修复LDAP长链接断开无法登录问题以及支持上传.yaml扩展名文件

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -84,11 +84,15 @@ module.exports = class UserController {
 
     /* istanbul ignore if */
     if (ldapUtil.enable) {
+      let ldap = await ldapUtil.createClient()
+
       try {
-        verifyPassword = await ldapUtil.authenticate(name, password)
+        verifyPassword = await ldapUtil.authenticate(ldap, name, password)
       } catch (error) {
         ctx.body = ctx.util.refail(error.message)
         return
+      } finally {
+        ldapUtil.closeClient(ldap)
       }
       if (verifyPassword && !user) {
         user = await createUser(name, util.bhash(password))

--- a/test/gen.js
+++ b/test/gen.js
@@ -12,7 +12,7 @@ const config = {
   upload: {
     dir: '../public/upload/test',
     expire: {
-      types: ['.json'],
+      types: ['.json', '.yml', '.yaml'],
       day: 1
     }
   }

--- a/test/util/ldap.test.js
+++ b/test/util/ldap.test.js
@@ -51,28 +51,33 @@ server.listen(1389)
 
 describe('test/util/ldap.test.js', () => {
   test('connection', async () => {
+    let ldapClient
     try {
-      await ldapUtil.authenticate('demo@example.com', '123456')
+      ldapClient = await ldapUtil.createClient()
+      await ldapUtil.authenticate(ldapClient, 'demo@example.com', '123456')
     } catch (error) {
       expect(error.message).toEqual('LDAP connection is not yet bound')
+    } finally {
+      ldapUtil.closeClient(ldapClient)
     }
   })
 
   test('authenticate', (done) => {
     setTimeout(async () => {
-      const user = await ldapUtil.authenticate('demo@example.com', '123456')
+      let ldapClient = await ldapUtil.createClient()
+      const user = await ldapUtil.authenticate(ldapClient, 'demo@example.com', '123456')
       expect(user).toBeTruthy()
       try {
-        await ldapUtil.authenticate('demo@example.com', '1234567')
+        await ldapUtil.authenticate(ldapClient, 'demo@example.com', '1234567')
       } catch (error) {
         expect(error.message).toEqual('用户名或密码错误')
       }
-
       try {
-        await ldapUtil.authenticate('demo2@example.com', '123456')
+        await ldapUtil.authenticate(ldapClient, 'demo2@example.com', '123456')
       } catch (error) {
         expect(error.message).toEqual('用户名或密码错误')
       }
+      ldapUtil.closeClient(ldapClient)
       done()
     }, 1000)
   })

--- a/util/ldap.js
+++ b/util/ldap.js
@@ -30,37 +30,40 @@ function createClient (opts) {
 
     client.once('connect', onConnect)
     client.once('error', onError)
-    client.once('connectTimeout', /* istanbul ignore next */ () => {
+    client.once('connectTimeout', /* istanbul ignore next */() => {
       onError(new Error('connect timeout'))
     })
   })
 }
 
 class LDAPUtil {
-  constructor () {
-    createClient({
+  async createClient () {
+    return createClient({
       url: ldapConf.server,
       credentials: {
         dn: ldapConf.bindDN,
         passwd: ldapConf.password
       }
     }).then(client => {
-      this._adminClient = client
+      return client
     })
+  }
+  async closeClient (client) {
+    client.destroy()
   }
   get enable () {
     return !!ldapConf.server
   }
-  async authenticate (username, password) {
+  async authenticate (client, username, password) {
     return new Promise((resolve, reject) => {
-      if (!this._adminClient) return reject(new Error('LDAP connection is not yet bound'))
+      if (!client) return reject(new Error('LDAP connection is not yet bound'))
 
       const opts = {
         scope: 'sub',
         filter: `(${ldapConf.filter.attributeName}=${username})`
       }
 
-      this._adminClient.search(ldapConf.filter.base, opts, (err, search) => {
+      client.search(ldapConf.filter.base, opts, (err, search) => {
         /* istanbul ignore if */
         if (err) return reject(new Error(err))
 
@@ -76,6 +79,7 @@ class LDAPUtil {
 
         search.on('end', result => {
           if (items.length === 1) {
+            console.log('create ldap client for user bind')
             createClient({
               url: ldapConf.server,
               credentials: {
@@ -83,6 +87,7 @@ class LDAPUtil {
                 passwd: password
               }
             }).then(client => {
+              // unbind connection is disconnected
               client.unbind(() => resolve(true))
             }).catch(() => {
               reject(new Error('用户名或密码错误'))

--- a/views/pages/new/project.vue
+++ b/views/pages/new/project.vue
@@ -57,7 +57,7 @@
               type="drag"
               :headers="uploadHeaders"
               :show-upload-list="false"
-              :format="['json','yml']"
+              :format="['json','yml', 'yaml']"
               :action="uploadAPI"
               :on-success="handleSwaggerUploadSuccess"
               :on-format-error="handleSwaggerUploadError"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch, not the `master` branch
- [ ] comply with the ESLint configuration of [Standard](http://standardjs.com)
- [ ] Rebase before creating a PR to keep commit history clear
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. fix #xxx[,#xxx], where "xxx" is the issue number)
- [ ] All tests are passing

**Other information:**
1. 当前LDAP登录客户端属于单例、一旦连接异常无法重建，ldap服务器通常会主动断开空闲/超时连接，因此改为每次登录重建ldap client 验证完后 使用ldap client destroy方法销毁建立的client。
2. 项目页面设置 只支持  .yml 和 .json扩展名的文件，新增支持.yaml文件。
